### PR TITLE
fix: update PM2 config to use port 443

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -10,7 +10,7 @@ module.exports = {
       interpreter: "none",
       env: {
         NODE_ENV: process.env.NODE_ENV || "production",
-        PORT: process.env.PORT || "3000",
+        PORT: process.env.PORT || "443",
         // Any other ENV vars will be injected from .env via restart.sh + --update-env
       },
       autorestart: true,


### PR DESCRIPTION
## Summary
- ensure PM2 ecosystem uses port 443 by default

## Testing
- `npm test` *(fails: feedback end-to-end records feedback in feedback.jsonl)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8f3de3083299053ddbe674dd33e