### PR TITLE
feat: add resume upload endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.csv
 /.vscode
 *.jsonl
+uploads/

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ const levelResult = await levelChain({
 });
 ```
 
+### Upload Resume
+
+Upload a PDF resume and the server will store the original file along with a plain
+text version for later analysis:
+
+```bash
+curl -X POST -H "Content-Type: application/pdf" --data-binary @resume.pdf \
+  http://localhost:3000/upload-resume
+```
+
 ## 🧪 Testing
 
 ### Smoke Tests

--- a/test/fixtures/sample.pdf
+++ b/test/fixtures/sample.pdf
@@ -1,0 +1,6 @@
+%PDF-1.1
+1 0 obj
+<<>>
+endobj
+(Hello resume)
+%%EOF

--- a/test/uploadResume.test.ts
+++ b/test/uploadResume.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import app from '../server';
+import path from 'path';
+import fs from 'fs/promises';
+
+describe('Upload Resume', () => {
+  const uploadDir = path.join(__dirname, '..', 'uploads', 'resumes');
+
+  it('should store pdf and extracted text', async () => {
+    const pdfPath = path.join(__dirname, 'fixtures', 'sample.pdf');
+    const buffer = await fs.readFile(pdfPath);
+    const res = await request(app)
+      .post('/upload-resume')
+      .set('Content-Type', 'application/pdf')
+      .send(buffer);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.text).toContain('Hello resume');
+
+    const storedPdf = path.join(uploadDir, res.body.file);
+    const storedTxt = storedPdf + '.txt';
+    await fs.access(storedPdf);
+    await fs.access(storedTxt);
+    const textContent = await fs.readFile(storedTxt, 'utf8');
+    expect(textContent).toContain('Hello resume');
+  });
+});


### PR DESCRIPTION
## Summary
- allow users to upload a PDF resume and extract plain text
- save uploads outside of version control
- document resume upload API and add test coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60591db888329922758a82595d386